### PR TITLE
fix: check sizes is not undefined

### DIFF
--- a/src/utils/sumUp.js
+++ b/src/utils/sumUp.js
@@ -1,15 +1,17 @@
 export default function sumUp(arr) {
   let newArr = [];
   arr.forEach((i) => {
-    const obj = newArr.find((o) => o.sizes.id === i.sizes.id);
-    if (obj) {
-      if (obj.total + i.total > obj.sizes.quantity) {
-        obj.total = obj.sizes.quantity;
+    if (i.sizes !== undefined) {
+      const obj = newArr.find((o) => o.sizes.id === i.sizes.id);
+      if (obj) {
+        if (obj.total + i.total > obj.sizes.quantity) {
+          obj.total = obj.sizes.quantity;
+        } else {
+          obj.total = obj.total + i.total;
+        }
       } else {
-        obj.total = obj.total + i.total;
+        newArr.push(i);
       }
-    } else {
-      newArr.push(i);
     }
   });
   return newArr;


### PR DESCRIPTION
Before fixing it, I got a bug `i.sizes` is `undefined` and can't read id. (`i.sizes.id`)
So, I check that the function should run when `i.sizes` is not undefined.